### PR TITLE
Fix valgrind uninitialized value error.

### DIFF
--- a/src/parcsr_ls/par_amg_solve.c
+++ b/src/parcsr_ls/par_amg_solve.c
@@ -160,7 +160,7 @@ hypre_BoomerAMGSolve( void               *amg_vdata,
     *    Compute initial fine-grid residual and print 
     *-----------------------------------------------------------------------*/
 
-   if (amg_print_level > 1 || amg_logging > 1)
+   if (amg_print_level > 1 || amg_logging > 1 || tol > 0.)
    {
      if ( amg_logging > 1 ) {
         hypre_ParVectorCopy(F_array[0], Residual );


### PR DESCRIPTION
resid_nrm is used on line 260 without being initialized unless this
extra check is done.

Discovered-by: Yaqi Wang <Yaqi.Wang@inl.gov>